### PR TITLE
Update RowEncoder's usage for Spark 3.5.0 support

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/rapids/GpuXGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/rapids/GpuXGBoost.scala
@@ -380,7 +380,7 @@ private[spark] object GpuXGBoost {
       .groupBy(groupName)
       .agg(collect_list(struct(schema.fieldNames.map(col): _*)) as "list")
 
-    implicit val encoder = RowEncoder(schema)
+    implicit val encoder = RowEncoder.encoderFor(schema)
     // Expand the grouped rows after repartition
     groupedDF.repartition(nWorkers).mapPartitions(iter => {
       new Iterator[Row] {


### PR DESCRIPTION
# Note
This PR targets to support new `RowEncoder`'s usage against Spark 3.5.0.

# Testing
I have tested this PR during AWS EMR development process: successfully built against Spark 3.5.0 and verified during EMR's integration testing.